### PR TITLE
Add the `PlainTextBuilder` and `MarkdownBuilder` builder & DSLs, along with their parent `TextBuilder` abstraction

### DIFF
--- a/src/main/kotlin/eth/rochsolid/slack/blocks/dsl/compositionobjects/TextBuilder.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/dsl/compositionobjects/TextBuilder.kt
@@ -1,0 +1,19 @@
+package eth.rochsolid.slack.blocks.dsl.compositionobjects
+
+import eth.rochsolid.slack.blocks.models.compositionobjects.Text
+
+sealed class TextBuilder<T : Text>(protected val text: String) {
+    abstract fun build(): T
+}
+
+class MarkdownBuilder(text: String) : TextBuilder<Text.Markdown>(text) {
+    var verbatim: Boolean? = null
+
+    override fun build(): Text.Markdown = Text.Markdown(text = text, verbatim = verbatim)
+}
+
+class PlainTextBuilder(text: String) : TextBuilder<Text.PlainText>(text) {
+    var emoji: Boolean? = null
+
+    override fun build(): Text.PlainText = Text.PlainText(text = text, emoji = emoji)
+}

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/Button.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/Button.kt
@@ -62,7 +62,7 @@ data class Button(
      * Maximum length is 255 characters.
      */
     @SerialName("action_id")
-    val actionId: ActionID?,
+    override val actionID: ActionID?,
     /**
      * A URL to load in the user's browser when the button is clicked.
      * Maximum length is 3000 characters.

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/Checkboxes.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/Checkboxes.kt
@@ -77,7 +77,7 @@ data class Checkboxes(
      * Maximum length is 255 characters.
      */
     @SerialName("action_id")
-    val actionId: ActionID?,
+    override val actionID: ActionID?,
     /**
      * A list of [Option] option objects. A maximum of 10 options are allowed.
      */

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/DatePicker.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/DatePicker.kt
@@ -38,7 +38,7 @@ data class DatePicker(
      * Maximum length is 255 characters.
      */
     @SerialName("action_id")
-    val actionId: ActionID?,
+    override val actionID: ActionID?,
     /**
      * A [ConfirmationDialog] object that defines an optional confirmation dialog after the button
      * is clicked.

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/DatetimePicker.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/DatetimePicker.kt
@@ -42,7 +42,7 @@ data class DatetimePicker(
      * Maximum length is 255 characters.
      */
     @SerialName("action_id")
-    val actionId: ActionID?,
+    override val actionID: ActionID?,
     /**
      * A [ConfirmationDialog] object that defines an optional confirmation dialog after the button
      * is clicked.

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/Element.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/Element.kt
@@ -20,6 +20,15 @@ sealed class Element(
      */
     val type: Type
 ) {
+    /**
+     * An identifier for this action.
+     * You can use this when you receive an interaction payload to identify the source of the action.
+     * Should be unique among all other `action_id`s in the containing block.
+     * Maximum length is 255 characters.
+     */
+    @SerialName("action_id")
+    abstract val actionID: ActionID?
+
     enum class Type {
         @SerialName("button")
         BUTTON,

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/EmailInput.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/EmailInput.kt
@@ -36,7 +36,7 @@ data class EmailInput(
      * Maximum length is 255 characters.
      */
     @SerialName("action_id")
-    val actionId: ActionID?,
+    override val actionID: ActionID?,
     /**
      * A dispatch configuration object that determines when during text input the element returns a [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions).
      */

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/FileInput.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/FileInput.kt
@@ -39,7 +39,7 @@ data class FileInput(
      * Maximum length is 255 characters.
      */
     @SerialName("action_id")
-    val actionId: ActionID?,
+    override val actionID: ActionID?,
     /**
      * A set of valid [FileExtension] [file extensions](https://api.slack.com/types/file#types) that will be accepted
      * for this element.

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/RichTextInput.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/RichTextInput.kt
@@ -5,7 +5,6 @@ import eth.rochsolid.slack.blocks.models.compositionobjects.DispatchActionConfig
 import eth.rochsolid.slack.blocks.models.compositionobjects.Text
 import kotlinx.serialization.SerialName
 
-
 /**
  * Allows users to enter formatted text in a WYSIWYG composer, offering the same messaging writing experience as in Slack.
  * Interactive component - see the [guide to enabling interactivity](https://api.slack.com/interactivity/handling).
@@ -37,7 +36,7 @@ data class RichTextInput(
      * Maximum length is 255 characters.
      */
     @SerialName("action_id")
-    val actionId: ActionID?,
+    override val actionID: ActionID?,
     /**
      * A dispatch configuration object that determines when during text input the element returns a
      * [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions).

--- a/src/test/kotlin/eth/rochsolid/slack/blocks/dsl/compositionobjects/MarkdownBuilderTest.kt
+++ b/src/test/kotlin/eth/rochsolid/slack/blocks/dsl/compositionobjects/MarkdownBuilderTest.kt
@@ -1,0 +1,48 @@
+package eth.rochsolid.slack.blocks.dsl.compositionobjects
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import eth.rochsolid.slack.blocks.models.compositionobjects.Text
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+internal class MarkdownBuilderTest {
+    @ParameterizedTest
+    @DisplayName(
+        "Given all fields are specified " +
+                "When building " +
+                "Then an instance of the markdown composition object is returned with all the fields populated"
+    )
+    @ValueSource(booleans = [true, false])
+    fun t1(verbatim: Boolean) {
+        val result = MarkdownBuilder("A message *with some bold text* and _some italicized text_.").apply {
+            this.verbatim = verbatim
+        }.build()
+
+        assertThat(result).isEqualTo(
+            Text.Markdown(
+                text = "A message *with some bold text* and _some italicized text_.",
+                verbatim = verbatim
+            )
+        )
+    }
+
+    @Test
+    @DisplayName(
+        "Given only required fields are specified " +
+                "When building " +
+                "Then an instance of the markdown composition object is returned with only the required fields populated"
+    )
+    fun t2() {
+        val result = MarkdownBuilder("A message *with some bold text* and _some italicized text_.").build()
+
+        assertThat(result).isEqualTo(
+            Text.Markdown(
+                text = "A message *with some bold text* and _some italicized text_.",
+                verbatim = null
+            )
+        )
+    }
+}

--- a/src/test/kotlin/eth/rochsolid/slack/blocks/dsl/compositionobjects/PlainTextBuilderTest.kt
+++ b/src/test/kotlin/eth/rochsolid/slack/blocks/dsl/compositionobjects/PlainTextBuilderTest.kt
@@ -1,0 +1,50 @@
+package eth.rochsolid.slack.blocks.dsl.compositionobjects
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import eth.rochsolid.slack.blocks.models.compositionobjects.Text
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+internal class PlainTextBuilderTest {
+    @ParameterizedTest
+    @DisplayName(
+        "Given all fields are specified " +
+                "When building " +
+                "Then an instance of the plain text composition object is returned " +
+                "And all the fields are populated"
+    )
+    @ValueSource(booleans = [true, false])
+    fun t1(emoji: Boolean) {
+        val result = PlainTextBuilder("A message with plain text.").apply {
+            this.emoji = emoji
+        }.build()
+
+        assertThat(result).isEqualTo(
+            Text.PlainText(
+                text = "A message with plain text.",
+                emoji = emoji
+            )
+        )
+    }
+
+    @Test
+    @DisplayName(
+        "Given only required fields are specified " +
+                "When building " +
+                "Then an instance of the plain text composition object is returned " +
+                "And only the required fields are populated"
+    )
+    fun t2() {
+        val result = PlainTextBuilder("A message with plain text.").build()
+
+        assertThat(result).isEqualTo(
+            Text.PlainText(
+                text = "A message with plain text.",
+                emoji = null
+            )
+        )
+    }
+}


### PR DESCRIPTION
Refs #21

Also, sneaked this in: declare `actionID: ActionID?` in parent `Element` type, and rename `actionId` to `actionID` consequently in all children types.