### PR TITLE
Add abstract `ActionableElement`, an `Element` sub-type with action ID, add the `Image` elements

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 assertk = "0.28.0"
-kotlinxSerialization = "1.6.3"
 junit = "5.10.2"
+kotlinxSerialization = "1.6.3"
 
 [libraries]
 assertk_core = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assertk" }
-kotlinx_serialization_json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 junit_jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+kotlinx_serialization_json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/dsl/blocks/BlockBuilder.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/dsl/blocks/BlockBuilder.kt
@@ -1,3 +1,6 @@
 package eth.rochsolid.slack.blocks.dsl.blocks
 
+import eth.rochsolid.slack.blocks.dsl.BlockDslMarker
+
+@BlockDslMarker
 sealed class BlockBuilder(var blockID: String? = null)

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/dsl/elements/ButtonBuilder.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/dsl/elements/ButtonBuilder.kt
@@ -3,8 +3,8 @@ package eth.rochsolid.slack.blocks.dsl.elements
 import eth.rochsolid.slack.blocks.dsl.BlockDslMarker
 import eth.rochsolid.slack.blocks.dsl.compositionobjects.ConfirmationDialogBuilder
 import eth.rochsolid.slack.blocks.dsl.compositionobjects.PlainTextBuilder
+import eth.rochsolid.slack.blocks.models.elements.ActionableElement
 import eth.rochsolid.slack.blocks.models.elements.Button
-import eth.rochsolid.slack.blocks.models.elements.Element
 import java.net.URL
 
 @BlockDslMarker
@@ -20,7 +20,7 @@ class ButtonBuilder(text: String) : ElementBuilder<Button>() {
 
     override fun build(): Button = Button(
         accessibilityLabel = accessibilityLabel,
-        actionID = actionID?.let(Element::ActionID),
+        actionID = actionID?.let(ActionableElement::ActionID),
         confirm = confirm?.build(),
         focusOnLoad = focusOnLoad,
         style = style,

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/Button.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/Button.kt
@@ -100,7 +100,7 @@ data class Button(
      */
     @SerialName("accessibility_label")
     val accessibilityLabel: String?
-) : Element(type = Type.BUTTON) {
+) : ActionableElement(type = Type.BUTTON) {
 
     enum class Style {
         /**

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/Checkboxes.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/Checkboxes.kt
@@ -100,4 +100,4 @@ data class Checkboxes(
      */
     @SerialName("focus_on_load")
     val focusOnLoad: Boolean? = false
-) : Element(type = Type.CHECKBOXES)
+) : ActionableElement(type = Type.CHECKBOXES)

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/DatePicker.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/DatePicker.kt
@@ -61,4 +61,4 @@ data class DatePicker(
      * Maximum length for the `text` in this field is 150 characters.
      */
     val placeholder: Text.PlainText?
-) : Element(type = Type.DATE_PICKER)
+) : ActionableElement(type = Type.DATE_PICKER)

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/DatetimePicker.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/DatetimePicker.kt
@@ -63,4 +63,4 @@ data class DatetimePicker(
      */
     @SerialName("initial_date_time")
     val initialDateTime: Instant?
-) : Element(type = Type.DATETIME_PICKER)
+) : ActionableElement(type = Type.DATETIME_PICKER)

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/Element.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/Element.kt
@@ -20,15 +20,6 @@ sealed class Element(
      */
     val type: Type
 ) {
-    /**
-     * An identifier for this action.
-     * You can use this when you receive an interaction payload to identify the source of the action.
-     * Should be unique among all other `action_id`s in the containing block.
-     * Maximum length is 255 characters.
-     */
-    @SerialName("action_id")
-    abstract val actionID: ActionID?
-
     enum class Type {
         @SerialName("button")
         BUTTON,
@@ -105,6 +96,17 @@ sealed class Element(
         @SerialName("workflow_button")
         WORKFLOW_BUTTON,
     }
+}
+
+sealed class ActionableElement(type: Type) : Element(type) {
+    /**
+     * An identifier for this action.
+     * You can use this when you receive an interaction payload to identify the source of the action.
+     * Should be unique among all other `action_id`s in the containing block.
+     * Maximum length is 255 characters.
+     */
+    @SerialName("action_id")
+    abstract val actionID: ActionID?
 
     /**
      * An action identifier.

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/EmailInput.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/EmailInput.kt
@@ -59,4 +59,4 @@ data class EmailInput(
      * Maximum length for the `text` in this field is 150 characters.
      */
     val placeholder: Text.PlainText?
-) : Element(type = Type.EMAIL_TEXT_INPUT)
+) : ActionableElement(type = Type.EMAIL_TEXT_INPUT)

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/FileInput.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/FileInput.kt
@@ -55,4 +55,4 @@ data class FileInput(
      * Defaults to 10 if not specified.
      */
     val maxFiles: Int? = DEFAULT_NUMBER_OF_UPLOADABLE_FILES
-) : Element(type = Type.FILE_INPUT)
+) : ActionableElement(type = Type.FILE_INPUT)

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/Image.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/Image.kt
@@ -1,0 +1,42 @@
+package eth.rochsolid.slack.blocks.models.elements
+
+import eth.rochsolid.slack.blocks.models.blocks.Image
+import kotlinx.serialization.SerialName
+import java.net.URL
+
+/**
+ * Displays an image as part of a larger block of content.
+ * Use the [Image] block if you want a block with only an image in it.
+ *
+ * Example ([view this example in the Block Kit Builder](https://api.slack.com/tools/block-kit-builder?blocks=%5B%0A%09%7B%0A%09%09%22type%22%3A%20%22section%22%2C%0A%09%09%22block_id%22%3A%20%22section567%22%2C%0A%09%09%22text%22%3A%20%7B%0A%09%09%09%22type%22%3A%20%22mrkdwn%22%2C%0A%09%09%09%22text%22%3A%20%22This%20is%20a%20section%20block%20with%20an%20accessory%20image.%22%0A%09%09%7D%2C%0A%09%09%22accessory%22%3A%20%7B%0A%09%09%09%22type%22%3A%20%22image%22%2C%0A%09%09%09%22image_url%22%3A%20%22https%3A%2F%2Fpbs.twimg.com%2Fprofile_images%2F625633822235693056%2FlNGUneLX_400x400.jpg%22%2C%0A%09%09%09%22alt_text%22%3A%20%22cute%20cat%22%0A%09%09%7D%0A%09%7D%0A%5D)):
+ * ```json
+ * {
+ *   "type": "image",
+ *   "image_url": "http://placekitten.com/700/500",
+ *   "alt_text": "Multiple cute kittens"
+ * }
+ * ```
+ */
+sealed class Image(
+    /**
+     * A plain-text summary of the image. This should not contain any markup.
+     */
+    @SerialName("alt_text")
+    val altText: String,
+) : Element(type = Type.IMAGE) {
+    data class UrlImage(
+        /**
+         * The URL for a publicly hosted image. Maximum length for this field is 3000 characters.
+         */
+        @SerialName("image_url")
+        val imageUrl: URL
+    )
+
+    data class SlackFileImage(
+        /**
+         * A [Image.SlackFile] Slack image file object that defines the source of the image.
+         */
+        @SerialName("slack_file")
+        val slackFile: Image.SlackFile
+    )
+}

--- a/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/RichTextInput.kt
+++ b/src/main/kotlin/eth/rochsolid/slack/blocks/models/elements/RichTextInput.kt
@@ -60,4 +60,4 @@ data class RichTextInput(
      * Maximum length for the `text` in this field is 150 characters.
      */
     val placeholder: Text.PlainText?
-) : Element(type = Type.RICH_TEXT_INPUT)
+) : ActionableElement(type = Type.RICH_TEXT_INPUT)

--- a/src/test/kotlin/eth/rochsolid/slack/blocks/dsl/blocks/ActionsBuilderTest.kt
+++ b/src/test/kotlin/eth/rochsolid/slack/blocks/dsl/blocks/ActionsBuilderTest.kt
@@ -6,6 +6,7 @@ import eth.rochsolid.slack.blocks.models.blocks.Actions
 import eth.rochsolid.slack.blocks.models.blocks.Block
 import eth.rochsolid.slack.blocks.models.compositionobjects.ConfirmationDialog
 import eth.rochsolid.slack.blocks.models.compositionobjects.Text
+import eth.rochsolid.slack.blocks.models.elements.ActionableElement
 import eth.rochsolid.slack.blocks.models.elements.Button
 import eth.rochsolid.slack.blocks.models.elements.Element
 import org.junit.jupiter.api.DisplayName
@@ -50,7 +51,7 @@ internal class ActionsBuilderTest {
                 blockID = Block.BlockID("actions1"),
                 elements = listOf(
                     Button(
-                        actionID = Element.ActionID("button"),
+                        actionID = ActionableElement.ActionID("button"),
                         text = Text.PlainText(
                             emoji = null,
                             text = "Click Me"

--- a/src/test/kotlin/eth/rochsolid/slack/blocks/dsl/blocks/ElementsBuilderTest.kt
+++ b/src/test/kotlin/eth/rochsolid/slack/blocks/dsl/blocks/ElementsBuilderTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import eth.rochsolid.slack.blocks.models.compositionobjects.ConfirmationDialog
 import eth.rochsolid.slack.blocks.models.compositionobjects.Text
+import eth.rochsolid.slack.blocks.models.elements.ActionableElement
 import eth.rochsolid.slack.blocks.models.elements.Button
 import eth.rochsolid.slack.blocks.models.elements.Element
 import org.junit.jupiter.api.DisplayName
@@ -42,7 +43,7 @@ internal class ElementsBuilderTest {
             },
             listOf(
                 Button(
-                    actionID = Element.ActionID("button"),
+                    actionID = ActionableElement.ActionID("button"),
                     text = Text.PlainText(
                         emoji = null,
                         text = "Click Me"

--- a/src/test/kotlin/eth/rochsolid/slack/blocks/dsl/compositionobjects/ConfirmationDialogBuilderTest.kt
+++ b/src/test/kotlin/eth/rochsolid/slack/blocks/dsl/compositionobjects/ConfirmationDialogBuilderTest.kt
@@ -8,28 +8,23 @@ import eth.rochsolid.slack.blocks.models.compositionobjects.ConfirmationDialog
 import eth.rochsolid.slack.blocks.models.compositionobjects.Text
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
 internal class ConfirmationDialogBuilderTest {
-    @Test
-    @DisplayName(
-        "Given all fields are specified " +
-                "And the button uses the primary style " +
-                "When building " +
-                "Then an instance of the confirmation dialog is returned with all the fields populated " +
-                "And the primary style"
-    )
-    fun t1() {
-        val result = ConfirmationDialogBuilder().apply {
-            title("Are you sure?")
-            text("Wouldn't you prefer a good game of chess?")
-            confirm("Do it :grinning:") {
-                emoji = true
-            }
-            deny("Stop, I've changed my mind!")
-            primaryStyle()
-        }.build()
-
-        assertThat(result).isEqualTo(
+    private fun successScenarios(): Stream<Arguments> = Stream.of(
+        Arguments.of(
+            ConfirmationDialogBuilder().apply {
+                title("Are you sure?")
+                text("Wouldn't you prefer a good game of chess?")
+                confirm("Do it :grinning:") {
+                    emoji = true
+                }
+                deny("Stop, I've changed my mind!")
+                primaryStyle()
+            },
             ConfirmationDialog(
                 title = Text.PlainText(
                     emoji = null,
@@ -49,29 +44,17 @@ internal class ConfirmationDialogBuilderTest {
                 ),
                 style = ConfirmationDialog.Style.PRIMARY
             )
-        )
-    }
-
-    @Test
-    @DisplayName(
-        "Given all fields are specified " +
-                "And the button uses the danger style " +
-                "When building " +
-                "Then an instance of the confirmation dialog is returned with all the fields populated " +
-                "And the danger style"
-    )
-    fun t2() {
-        val result = ConfirmationDialogBuilder().apply {
-            title("Are you sure?")
-            text("Wouldn't you prefer a good game of chess?")
-            confirm("Do it")
-            deny("Stop, I've changed my mind! :grinning:") {
-                emoji = true
-            }
-            dangerStyle()
-        }.build()
-
-        assertThat(result).isEqualTo(
+        ),
+        Arguments.of(
+            ConfirmationDialogBuilder().apply {
+                title("Are you sure?")
+                text("Wouldn't you prefer a good game of chess?")
+                confirm("Do it")
+                deny("Stop, I've changed my mind! :grinning:") {
+                    emoji = true
+                }
+                dangerStyle()
+            },
             ConfirmationDialog(
                 title = Text.PlainText(
                     emoji = null,
@@ -92,6 +75,19 @@ internal class ConfirmationDialogBuilderTest {
                 style = ConfirmationDialog.Style.DANGER
             )
         )
+    )
+
+    @ParameterizedTest
+    @MethodSource("successScenarios")
+    @DisplayName(
+        "Given a builder instance created via the DSL " +
+                "When building " +
+                "Then an instance of the type is created as expected"
+    )
+    fun t1(builder: ConfirmationDialogBuilder, expected: ConfirmationDialog) {
+        val result = builder.build()
+
+        assertThat(result).isEqualTo(expected)
     }
 
     @Test
@@ -100,7 +96,7 @@ internal class ConfirmationDialogBuilderTest {
                 "When building " +
                 "Then a UninitializedPropertyAccessException exception is thrown"
     )
-    fun t3() {
+    fun t2() {
         assertFailure {
             ConfirmationDialogBuilder().apply {
                 title("Are you sure?")

--- a/src/test/kotlin/eth/rochsolid/slack/blocks/dsl/elements/ButtonBuilderTest.kt
+++ b/src/test/kotlin/eth/rochsolid/slack/blocks/dsl/elements/ButtonBuilderTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import eth.rochsolid.slack.blocks.models.compositionobjects.ConfirmationDialog
 import eth.rochsolid.slack.blocks.models.compositionobjects.Text
+import eth.rochsolid.slack.blocks.models.elements.ActionableElement
 import eth.rochsolid.slack.blocks.models.elements.Button
 import eth.rochsolid.slack.blocks.models.elements.Element
 import org.junit.jupiter.api.DisplayName
@@ -38,7 +39,7 @@ internal class ButtonBuilderTest {
                 url = "https://slack.com"
             },
             Button(
-                actionID = Element.ActionID("button"),
+                actionID = ActionableElement.ActionID("button"),
                 text = Text.PlainText(
                     emoji = null,
                     text = "Click Me"


### PR DESCRIPTION
Refs #7

## Description
This set of changes add the abstract `Image` `ActionableElement` and its concrete `UrlImage` and `SlackFileImage` elements. It also introduces the abstract `ActionableElement` element, a sub-type of `Element` with an action ID. Most elements inherit from it, except for certain elements like the new `Image` elements being introduced with these changes, which inherit directly from `Element` are `Image` elements are not actionable.

## Changes in this Pull Request
- add `ActionableElement`, an abstract `Element` with an action ID
- remove `actionID` from `Element`: not all elements are actionable, so `actionID` is now only defined in the new `ActionableElement` type, a sub-type of `Element`
- update existing sub-types of `Element` to inherit from `ActionableElement`, as all existing types that use `Element` are `ActionableElement`s
- add the `Image` element a non-actionable `Element`
- sneaked this in: alphabetical order for `libs.versions.toml` properties, annotate `BlockBuilder` with `BlockDslMarker` for proper DSL scoping, using parameterized test for `ConfirmationDialogBuilderTest` success scenarios for consistency with other tests and ease of maintenance